### PR TITLE
Add CI workflow to build and push containers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: Build and Push Containers
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Log in to GHCR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "$GITHUB_TOKEN" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
+      - name: Build and push images
+        run: |
+          for dir in containers/*; do
+            image=$(basename "$dir")
+            docker build -t ghcr.io/${{ github.repository_owner }}/$image "$dir"
+            docker push ghcr.io/${{ github.repository_owner }}/$image
+          done
+


### PR DESCRIPTION
## Summary
- build all container directories with Docker
- push images to GHCR on pushes to `main` and tags

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845bb9ddca08325b60b5ead82c4bf62